### PR TITLE
fix compatibility issues for Matlab < 2017

### DIFF
--- a/ft_crex/db/cp_db_import.m
+++ b/ft_crex/db/cp_db_import.m
@@ -253,11 +253,12 @@ end
 % Copy MarsAtlas volume file from BRAINVISA_DATABASE to FIELDTRIP_DATABASE
 function copy_vol(Sbv, pbvin, pout)
 pvol = dir(fullfile(Sbv.dir, pbvin));
+folder  = fileparts(fullfile(Sbv.dir, pbvin));
 if isempty(pvol)
     warning('\nMRI file not found in BRAINVISA_DATABASE for subject %s\n', Sbv.subj)
     warning('Please copy the required files inside \n%s\n', pout)
 else
-    copyfile([pvol(1).folder, filesep, pvol(1).name], pout)
+    copyfile(folder, filesep, pvol(1).name], pout)
 end
 
 function Sdir = make_mdir(proot, cdir)


### PR DESCRIPTION
Test with Matlab<2017 by Valérie
Compatibility issues with:
- dir function that doesn't return the "folder" field
- autoupdate property for legend that doesn't exist in Matlab < 2017
(see in cp_pref to turn off the autoupdate property)